### PR TITLE
Handle X-Forwarded-Proto and X-Forwarded-Host headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ import secrets
 from flask import Flask, render_template, request
 from flask_login import LoginManager, current_user
 from flask_socketio import SocketIO, disconnect, emit, join_room, leave_room
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from config import *
 from models import User
@@ -32,6 +33,7 @@ port = int(os.environ.get("PORT", 5000))
 
 # construct app
 app = Flask(__name__)
+app.wsgi_app = ProxyFix(app.wsgi_app, x_host=1)
 app.config["SECRET_KEY"] = secrets.token_urlsafe(16)
 app.register_blueprint(user)
 


### PR DESCRIPTION
The plotter container is running behind a reverse proxy (Azure Front Door). This has a few implications:

* The source IP will always be the proxy address
* The app's host name isn't the host name used by end users

There's a pattern for reverse proxies to supply this data to apps - the X-* headers. Like a lot of reverse proxies, Azure Front Door [sets a lot of these](https://learn.microsoft.com/en-us/azure/frontdoor/front-door-http-headers-protocol). This PR uses Werkzeug middleware to process those headers and give correct data to Flask so `url_for()` works.